### PR TITLE
Update branding to L16

### DIFF
--- a/config/config.prod.jsonc
+++ b/config/config.prod.jsonc
@@ -1,22 +1,12 @@
 {
     "networks": [
         {
-            "name": "Sapphire Testnet",
-            "path": "/sapphire-testnet",
-            "joinURL": "https://prylabs.net/participate",
-            "HTTP_API": "https://api.sapphire.eth2stats.io/api",
-            "WS_API": "wss://api.sapphire.eth2stats.io/ws",
-            "SERVER_ADDR": "grpc.sapphire.eth2stats.io:443",
-            "SECONDS_PER_SLOT": 6
-        },
-        {
-            "name": "Lighthouse Testnet5",
-            "path": "/lighthouse-testnet5",
-            "joinURL": "https://lighthouse-book.sigmaprime.io/become-a-validator.html",
-            "HTTP_API": "https://api.summer.eth2stats.io/api",
-            "WS_API": "wss://api.summer.eth2stats.io/ws",
-            "SERVER_ADDR": "grpc.summer.eth2stats.io:443",
-            "SECONDS_PER_SLOT": 6
+            "name": "L16-testnet",
+            "path": "/",
+            "HTTP_API": "https://api.stats.consensus.l16.lukso.network/api",
+            "joinURL": "https://docs.lukso.tech/networks/l16-testnet/#how-to-participate",
+            "WS_API": "wss://api.stats.consensus.l16.lukso.network/ws",
+            "SERVER_ADDR": "stats.consensus.l16.lukso.network"
         }
     ]
 }

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -1,6 +1,6 @@
 {
- "name": "Eth2Stats",
- "short_name": "Eth2Stats",
+ "name": "L16Stats",
+ "short_name": "L16Stats",
  "theme_color": "#172232",
  "background_color": "#172232",
  "display": "standalone",

--- a/src/app/components/navigation/Logo.tsx
+++ b/src/app/components/navigation/Logo.tsx
@@ -30,7 +30,7 @@ export const Logo: React.FC<ILogoProps> = (props) => (
         </svg>
         <div className="hidden sm:flex items-center">
             <div className="ml-4 flex">
-                <p className="logo-text font-sm font-bold text-white">LUKSO Stats</p>
+                <p className="logo-text font-sm font-bold text-white">L16 Stats</p>
             </div>
             {
                 props.network &&

--- a/src/app/components/navigation/Logo.tsx
+++ b/src/app/components/navigation/Logo.tsx
@@ -30,8 +30,7 @@ export const Logo: React.FC<ILogoProps> = (props) => (
         </svg>
         <div className="hidden sm:flex items-center">
             <div className="ml-4 flex">
-                <p className="logo-text font-sm font-bold text-white">eth2stats</p>
-                <p className="font-xxs font-semibold text-grey-500 ml-1 -mt-1">(alpha)</p>
+                <p className="logo-text font-sm font-bold text-white">LUKSO Stats</p>
             </div>
             {
                 props.network &&

--- a/src/app/components/table/Table.tsx
+++ b/src/app/components/table/Table.tsx
@@ -31,7 +31,8 @@ export const Table: React.FC = observer(() => {
                         :
                         client.clientVersionStatus === "ok"
                             ?
-                            <span className="text-alethio-green">Your LUKSO stats-client is up-to-date. High five!</span>
+                            <span className="text-alethio-green">Your LUKSO stats-client is up-to-date. High five!
+                            </span>
                             :
                             <span className="text-grey-500">The client version is unknown.</span>
                 }

--- a/src/app/components/table/Table.tsx
+++ b/src/app/components/table/Table.tsx
@@ -31,7 +31,7 @@ export const Table: React.FC = observer(() => {
                         :
                         client.clientVersionStatus === "ok"
                             ?
-                            <span className="text-alethio-green">Your eth2stats-client is up-to-date. High five!</span>
+                            <span className="text-alethio-green">Your LUKSO stats-client is up-to-date. High five!</span>
                             :
                             <span className="text-grey-500">The client version is unknown.</span>
                 }

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Eth2Stats (alpha) - Ethereum 2.0 Network Monitor</title>
+    <title>LUKSO L16 Testnet Network Monitor</title>
     <!-- Google Tag Manager -->
     <script>(function (w, d, s, l, i) {
         w[l] = w[l] || []; w[l].push({


### PR DESCRIPTION
### Description

This PR updates the branding of the eth2stats dashboard (consensus stats monitoring) to reflect L16 testnet branding and make it easier for network participants to process the information on the page

<img width="1322" alt="image" src="https://user-images.githubusercontent.com/30433120/176392137-629869d0-1988-4498-abbe-e5d8a4ed1bf3.png">

### How to test
- Pull branch and install dependencies as needed (you may require Node v8 for webpack to work properly)
- In one terminal: `npm run watch`
- In another terminal: `npm start`